### PR TITLE
トップページの口コミに飲食店情報表示

### DIFF
--- a/app/(page)/bases/[baseId]/top/page.tsx
+++ b/app/(page)/bases/[baseId]/top/page.tsx
@@ -40,7 +40,7 @@ const TopPage = () => {
 
         <div>
           <h2>{PAGE_SUB_TITLES.TOP.RECENT_REVIEWS}</h2>
-          <Reviews reviews={reviews} direction={'column'}/>
+          <Reviews reviews={reviews} direction={'column'} isAddingShop={true} />
         </div>
       </div>
     </>

--- a/app/_components/button/linkButton/index.tsx
+++ b/app/_components/button/linkButton/index.tsx
@@ -4,7 +4,7 @@ import styles from './LinkButton.module.css'
 interface LinkButtonProps{
   text: string;
   href: string;
-  styleType?: 'shopName' | 'shopUrl' |string;
+  styleType?: 'shopName' | 'shopUrl' ;
 }
 
 // リンクボタン

--- a/app/_components/reviews/Review.tsx
+++ b/app/_components/reviews/Review.tsx
@@ -2,16 +2,22 @@ import { PAGE_LABELS } from "@/app/_constants/pageText";
 import { ReviewData } from "@/app/_interfaces/dto/response/ReviewData";
 
 import styles from "./Reviews.module.css"
+import LinkButton from "../button/linkButton";
+import { PAGE_PATHS } from "@/app/_constants/pagePath";
 
 interface ReviewProps{
   review: ReviewData;
+  isAddingShop?: boolean;
 }
 
 // 口コミ一件表示
-const Review = ({review}: ReviewProps) => {
+const Review = ({review, isAddingShop}: ReviewProps) => {
   return(
     <div className={styles.review}>
       <img src={review.img_path} alt="口コミ" style={{width: '25vw'}}/>
+      {isAddingShop && 
+        <LinkButton text={`${PAGE_LABELS.SHOP.NAME}：${review.shop.name}`} href={PAGE_PATHS.SHOP_DETAIL(review.shop.base.id, review.shop.id)} styleType="shopName" />
+      }
       <p>{PAGE_LABELS.REVIEW.CREATED_AT}：{review.createdAt}</p>
       <p>{PAGE_LABELS.REVIEW.USER}：{review.user.name}</p>
       <p>{PAGE_LABELS.REVIEW.COMMENT}：{review.comment}</p>

--- a/app/_components/reviews/Reviews.module.css
+++ b/app/_components/reviews/Reviews.module.css
@@ -1,5 +1,4 @@
 /* 口コミに対応するCSS */
-
 .reviews{
   display: flex;
 }
@@ -14,4 +13,8 @@
   margin: 1rem;
   padding: 1rem;
   background-color: burlywood;
+}
+
+.shopName{
+  font-size: 2rem;
 }

--- a/app/_components/reviews/index.tsx
+++ b/app/_components/reviews/index.tsx
@@ -6,10 +6,11 @@ import styles from "./Reviews.module.css"
 interface ReviewsProps{
   reviews: ReviewData[];
   direction?: 'row' | 'column';
+  isAddingShop?:boolean;
 }
 
 // 口コミリスト表示
-const Reviews = ({reviews, direction}: ReviewsProps) => {
+const Reviews = ({reviews, direction, isAddingShop}: ReviewsProps) => {
   const classNames = [styles.reviews];
   if(direction === 'column'){
     classNames.push(styles.column);
@@ -17,7 +18,7 @@ const Reviews = ({reviews, direction}: ReviewsProps) => {
   return(
     <div className={classNames.join(' ')}>
       {reviews.map((review) => (
-        <Review key={review.id} review={review} />
+        <Review key={review.id} review={review} isAddingShop={isAddingShop} />
       ))}
     </div>
   );


### PR DESCRIPTION
# What
- トップページの口コミに飲食店情報表示
  - 口コミコンポーネントにショップ情報を追加するかどうかのプロップスを追加
#Why
- トップのレビューは店に紐づいていなく、最新のレビューを表示してるので飲食店情報が必要なため